### PR TITLE
add rule for leak object and call Destroy is .dpr files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Last Changes
   * Add rule to detect leak many classes of class fields
   * Leak local variables also see many classes
 
-Version 1.0.1 
+Version 1.0.3 
   * Add rule to detect leak object of TList, TStringList of local variables procedures and functions
   * Add rule for detect call .Destroy
   
@@ -18,7 +18,7 @@ Is a SonarQube (http://www.sonarqube.org/) plugin and provides
   * TestCoverage using AQtime (license needed)
   * Optional .html output for TestCoverage
 
-This is Plugin-Version 1.0.1 for SonarQube 7.1. 
+This is Plugin-Version 1.0.3 for SonarQube 7.1. 
 It is is mainly an updated version of https://github.com/fabriciocolombo/sonar-delphi and https://github.com/SandroLuck/SonarDelphi all credit goes to them.
 I have hosted it here since the orignal developer isn't active anymore.
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 
 	<artifactId>sonar-delphi-plugin</artifactId>
-	<version>1.0.2</version>
+	<version>1.0.3</version>
 	<groupId>org.delphi.plugin</groupId>
 	<name>Sonar Delphi Plugin</name>
 	<description>Enables analysis of Delphi projects.</description>

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/LeakDprObjectRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/LeakDprObjectRule.java
@@ -1,0 +1,35 @@
+package org.sonar.plugins.delphi.pmd.rules;
+
+import net.sourceforge.pmd.RuleContext;
+import org.sonar.plugins.delphi.antlr.DelphiLexer;
+import org.sonar.plugins.delphi.antlr.ast.DelphiPMDNode;
+
+public class LeakDprObjectRule extends MayBeLeakLocalObjectRule {
+
+    private int check;
+
+    @Override
+    public void init() {
+        super.init();
+        // needs to check at new file
+        check = -1;
+    }
+
+    @Override
+    public void visit(DelphiPMDNode node, RuleContext ctx) {
+        if (check == -1) {
+            if (node.getASTTree().getFileName().endsWith(".dpr") || node.getASTTree().getFileName().endsWith(".dpk")) {
+                check = 1;
+            } else {
+                check = 0;
+            }
+        }
+        if (check != 1) {
+            // not a .dpr/.dpk file
+            return;
+        }
+        isProcessed = true;
+        calcLevel(node, ctx);
+        isProcessed = checkCreateAndFree(node);
+    }
+}

--- a/src/main/resources/org/sonar/plugins/delphi/pmd/rules.xml
+++ b/src/main/resources/org/sonar/plugins/delphi/pmd/rules.xml
@@ -16,7 +16,8 @@
 	(...)		
 	<b>end;</b>		
 <b>except</b>		
-(...)		
+<b>except</b>
+(...)
 <b>end;		
  		]]></example>
 	</rule>
@@ -378,6 +379,22 @@ end;
  		]]></example>
 	</rule>
 
+	<rule since="" class="org.sonar.plugins.delphi.pmd.rules.LeakDprObjectRule" message="You forgot to destroy the created object in dpr"
+		  name="LeakDprObjectRule">
+		<description>Call obj.Free or FreeAndNil(obj). Strong check on assign and pass as parameter
+		</description>
+		<tags>bug</tags>
+		<example><![CDATA[
+procedure Test();
+var list : TList;
+begin
+  list := TList.Create;
+  list.add(nil);
+  ShowMessage(IntToStr(list.Count));
+  // !! forgot list.Free ???
+end;
+ 		]]></example>
+	</rule>
 
 	<rule since="" class="org.sonar.plugins.delphi.pmd.rules.FreeLocalObjectInFinallyRule" message="Free local object in finally section"
 		  name="FreeLocalObjectInFinallyRule">
@@ -533,6 +550,7 @@ x := a or x := not a;   //GOOD
 
 	<rule since="" class="org.sonar.plugins.delphi.pmd.rules.DprFunctionRule" message=".dpr/.dpk file should not have procedures/functions."
 		name="ProjectFileNoFunctionsRule">
+		<tags>security</tags>
 		<description>.dpr/.dpk files should not have procedures/functions.</description>
 	</rule>
 

--- a/src/test/java/org/sonar/plugins/delphi/pmd/BasePmdRuleTest.java
+++ b/src/test/java/org/sonar/plugins/delphi/pmd/BasePmdRuleTest.java
@@ -75,7 +75,7 @@ public abstract class BasePmdRuleTest {
   private RulesProfile rulesProfile;
 
   public void analyse(DelphiUnitBuilderTest builder) {
-    testFile = builder.buildFile(ROOT_DIR);
+    testFile = builder.buildFile(ROOT_DIR, builder.getFileSufix());
     configureTest();
 
     DebugSensorContext sensorContext = new DebugSensorContext();

--- a/src/test/java/org/sonar/plugins/delphi/pmd/DelphiUnitBuilderTest.java
+++ b/src/test/java/org/sonar/plugins/delphi/pmd/DelphiUnitBuilderTest.java
@@ -37,6 +37,15 @@ public class DelphiUnitBuilderTest {
     private int offset;
     private int offsetDecl;
     private String unitName = "Unit1";
+    private String fileSufix = ".pas";
+
+    public void setFileSufix(String fileSufix) {
+        this.fileSufix = fileSufix;
+    }
+
+    public String getFileSufix() {
+        return fileSufix;
+    }
 
     public DelphiUnitBuilderTest appendDecl(String value) {
         declaration.append(value).append("\n");
@@ -62,11 +71,11 @@ public class DelphiUnitBuilderTest {
         return this;
     }
 
-    File buildFile(File baseDir) {
+    File buildFile(File baseDir, String sufix) {
         StringBuilder source = getSourceCode();
 
         try {
-            File file = File.createTempFile("unit", ".pas", baseDir);
+            File file = File.createTempFile("unit", sufix, baseDir);
             file.deleteOnExit();
 
             try (FileWriter fileWriter = new FileWriter(file)) {
@@ -86,17 +95,23 @@ public class DelphiUnitBuilderTest {
         offset = offset + 6;
 
         StringBuilder source = new StringBuilder();
-        source.append(String.format("unit %s;\n", this.unitName));
-        source.append("\n");
-        source.append("interface\n");
-        source.append("\n");
+        if (fileSufix.equals(".pas")){
+            source.append(String.format("unit %s;\n", this.unitName));
+            source.append("\n");
+            source.append("interface\n");
+            source.append("\n");
+        }else {
+            source.append(String.format("program %s;\n", this.unitName));
+        }
 
         if (this.declaration.length() > 0) {
             source.append(this.declaration()).append("\n");
             offset++;
         }
-        source.append("implementation\n");
-        source.append("\n");
+        if (fileSufix.equals(".pas")){
+            source.append("implementation\n");
+            source.append("\n");
+        }
 
         if (this.implementation.length() > 0) {
             source.append(this.implementation()).append("\n");

--- a/src/test/java/org/sonar/plugins/delphi/pmd/LeakDprObjectTest.java
+++ b/src/test/java/org/sonar/plugins/delphi/pmd/LeakDprObjectTest.java
@@ -1,0 +1,51 @@
+package org.sonar.plugins.delphi.pmd;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+public class LeakDprObjectTest extends BasePmdRuleTest {
+
+    @Test
+    public void validRule() {
+        DelphiUnitBuilderTest builder = new DelphiUnitBuilderTest();
+        builder.setFileSufix(".dpr");
+        builder.appendImpl("" +
+                "\n" +
+                "procedure Test;\n" +
+                "var\n" +
+                "  ss: TStaticSet;\n" +
+                "begin\n" +
+                "  ss := TStaticSet.Create;\n" +
+                "  ss.KeyFieldNames := RBParam.Keys;\n" +
+                "  ss.Free;\n" +
+                "end;\n" +
+                "begin\n" +
+                "Test;\n" +
+                "");
+
+        analyse(builder);
+        assertThat(issues, is(hasSize(2))); //на код теста ругаются правила DprVariableRule и DprFunctionRule
+    }
+
+    @Test
+    public void validRule2() {
+        DelphiUnitBuilderTest builder = new DelphiUnitBuilderTest();
+        builder.setFileSufix(".dpr");
+        builder.appendImpl("" +
+                "\n" +
+                "var\n" +
+                "  ss: TStaticSet;\n" +
+                "begin\n" +
+                "  ss := TStaticSet.Create;\n" +
+                "  ss.KeyFieldNames := RBParam.Keys;\n" +
+                "  ss.Free;\n" +
+                "");
+
+        analyse(builder);
+        assertThat(issues, is(hasSize(1))); //на код теста ругается правило DprVariableRule
+    }
+}


### PR DESCRIPTION
Добавлено правило для .dpr файлов, проверяющие обязательность удаления созданных объектов.