### PR TITLE
fix rule for leak object and call Destroy fields in classes

### DIFF
--- a/src/main/java/org/sonar/plugins/delphi/antlr/ast/DelphiAST.java
+++ b/src/main/java/org/sonar/plugins/delphi/antlr/ast/DelphiAST.java
@@ -204,7 +204,7 @@ public class DelphiAST extends CommonTree implements ASTTree {
   /**
    * Some characters are forbidden as XML node, so process them
    * 
-   * @param str String to process
+   * @param node to process
    * @return Fixed string
    */
   private String processNodeName(Tree node) {

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/LeakClassObjectRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/LeakClassObjectRule.java
@@ -87,7 +87,7 @@ public class LeakClassObjectRule extends DelphiRule {
         if (methodLevel == 0)
             inClassName = null;
 
-        if (beginLevel == 0)
+        if (methodLevel == 0)
             return;
 
         // отслеживаем создание; определяем переменную.

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/LeakDprObjectRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/LeakDprObjectRule.java
@@ -1,7 +1,6 @@
 package org.sonar.plugins.delphi.pmd.rules;
 
 import net.sourceforge.pmd.RuleContext;
-import org.sonar.plugins.delphi.antlr.DelphiLexer;
 import org.sonar.plugins.delphi.antlr.ast.DelphiPMDNode;
 
 public class LeakDprObjectRule extends MayBeLeakLocalObjectRule {

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/LeakLocalObjectRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/LeakLocalObjectRule.java
@@ -8,7 +8,6 @@ public class LeakLocalObjectRule extends MayBeLeakLocalObjectRule {
 
     //TODO: forward directive in implementation section break method level counting
     // operator 'with' can make false result
-
     @Override
     public void visit(DelphiPMDNode node, RuleContext ctx) {
         super.visit(node, ctx);

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/MayBeLeakLocalObjectRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/MayBeLeakLocalObjectRule.java
@@ -43,10 +43,6 @@ public class MayBeLeakLocalObjectRule extends DelphiRule {
         add("TFileStream".toUpperCase());
     }};
 
-    public int getBeginLevel() {
-        return beginLevel;
-    }
-
     @Override
     protected void init() {
         isImplementation = false;


### PR DESCRIPTION
Исправлено правило проверяющие обязательность удаления созданных объектов в полях класса.